### PR TITLE
RPM packaging is separated from compilation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,7 @@
             </build>
         </profile>
 
-        <!-- To package this into an RPM, ensure RPM is installed on the build machine and run mvn compile with '-P rpm-package' -->
+        <!-- To package this into an RPM, ensure RPM is installed on the build machine. Compile then run 'mvn package -P rpm-package' -->
         <profile>
           <id>rpm-package</id>
           <build>
@@ -425,52 +425,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <!-- Commented to allow for local builds to succeed. Need some kind of conditional inclusion so local builds don't require RPM
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>rpm-maven-plugin</artifactId>
-                <version>2.1.5</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>rpm</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <license>2016, Kenzan Media, LLC</license>
-                    <group>Development</group>
-                    <description>Million Song Library account-edge</description>
-                    <needarch>x86_64</needarch>
-                    <provides>
-                        <provide>msl-account-edge</provide>
-                    </provides>
-                    <requires>
-                        <require>java-1.8.0-openjdk</require>
-                    </requires>
-                    <postinstallScriptlet>
-                        <scriptFile>install-account-edge.sh</scriptFile>
-                    </postinstallScriptlet>
-                    <mappings>
-                        <mapping>
-                            <directory>/opt/kenzan/</directory>
-                            <dependency/>
-                            <directoryIncluded>false</directoryIncluded>
-                            <sources>
-                                <source>
-                                    <location>target/${project.build.finalName}-jar-with-dependencies.jar</location>
-                                    <destination>/opt/kenzan/</destination>
-                                </source>
-                            </sources>
-                            <artifact/>
-                        </mapping>
-                        <mapping>
-                            <directory>/var/log/msl/</directory>
-                        </mapping>
-                    </mappings>
-                </configuration>
-            </plugin>
-            --> 
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -215,6 +215,59 @@
             </build>
         </profile>
 
+        <!-- To package this into an RPM, ensure RPM is installed on the build machine and run mvn compile with '-P rpm-package' -->
+        <profile>
+          <id>rpm-package</id>
+          <build>
+            <plugins>
+              <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                  <artifactId>rpm-maven-plugin</artifactId>
+                  <version>2.1.5</version>
+                  <executions>
+                    <execution>
+                      <goals>
+                        <goal>rpm</goal>
+                      </goals>
+                    </execution>
+                  </executions>
+                <configuration>
+                  <license>2016, Kenzan Media, LLC</license>
+                  <group>Development</group>
+                  <description>Million Song Library account-edge</description>
+                  <needarch>x86_64</needarch>
+                  <provides>
+                    <provide>msl-account-edge</provide>
+                  </provides>
+                  <requires>
+                    <require>java-1.8.0-openjdk</require>
+                  </requires>
+                  <postinstallScriptlet>
+                    <scriptFile>install-account-edge.sh</scriptFile>
+                  </postinstallScriptlet>
+                  <mappings>
+                    <mapping>
+                      <directory>/opt/kenzan/</directory>
+                        <dependency/>
+                        <directoryIncluded>false</directoryIncluded>
+                        <sources>
+                        <source>
+                          <location>target/${project.build.finalName}-jar-with-dependencies.jar</location>
+                          <destination>/opt/kenzan/</destination>
+                        </source>
+                      </sources>
+                      <artifact/>
+                    </mapping>
+                    <mapping>
+                      <directory>/var/log/msl/</directory>
+                    </mapping>
+                  </mappings>
+                </configuration>
+              </plugin>
+            </plugins>
+          </build>
+        </profile>
+
     </profiles>
 
     <build>


### PR DESCRIPTION
RPM packaging moved into its own profile. 'mvn compile -P rpm-package' will create the package.